### PR TITLE
UbuntuでもパスワードをDecrypt出来る様にする

### DIFF
--- a/admintools/DecryptString.sh
+++ b/admintools/DecryptString.sh
@@ -10,6 +10,17 @@
 #-  eval $(path/to/EncryptString.sh plainTextString)
 #-  decryptedString=$(path/to/DecryptString.sh -e $encryptedString -p $passphrase -s $salt)
 #-
+if [ -f "/etc/os-release" ]
+then
+ GREP="/bin/grep"
+ OPENSSL="/usr/bin/openssl"
+ OPENSSLOPT=" -md md5 "
+else
+ GREP="/usr/bin/grep"
+ OPENSSLOPT=""
+ OPENSSL="/usr/local/bin/openssl"
+fi
+
 
 while getopts e:f:s:p:h sw
 do
@@ -45,9 +56,10 @@ then
     ShowHelp=yes
 fi
 if [ "${ShowHelp:-no}" = yes ]; then
-    /usr/bin/grep ^#- "$0" | /usr/bin/cut -c 4-
+    $GREP ^#- "$0" | /usr/bin/cut -c 4-
     exit 1
 fi
 
-echo "$EncryptedString" | /usr/bin/openssl enc -aes256 -d -a -A -S "$Salt" -k "$PassPhrase"
+echo "$EncryptedString" | $OPENSSL enc -aes256 -d -a -A -S "$Salt" -k "$PassPhrase" $OPENSSLOPT
 exit "${PIPESTATUS[1]}"
+


### PR DESCRIPTION
Jamf Proの管理者はもちろんmacOSを業務で利用していてこのスクリプトをそのまま利用する事が出来ますが
社内ITサポートチームのメンバーはWindowsマシンを利用していたりして DecryptString.sh をそのまま動かす事が出来ません。

Windows 10 でWSL2を動かして居る環境で DecryptString.sh が使えるとITサポートチームがmacOSの諸々の対応を行う際に便利なので DecryptString.sh がUbuntu環境で動くように変更を行いました

## 主な変更点
 - grep コマンドと openssl コマンドのPATHの変更
 - opensslコマンドに渡すオプションの変更(ubuntu に入っているopensslでは `-md md5` が必要
